### PR TITLE
Feat: check install

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,2 +1,75 @@
-// Ignore node-gyp rebuild
-process.exit(0);
+const tryLoadPreBuilt = require('node-gyp-build');
+const proc = require('child_process')
+const os = require('os')
+const path = require('path')
+
+try {
+  if (!buildFromSource()) {
+    tryLoadPreBuilt(__dirname);
+  } else {
+    preinstall();
+  }
+} catch (e) {
+  preinstall();
+}
+
+function build () {
+  var args = [os.platform() === 'win32' ? 'node-gyp.cmd' : 'node-gyp', 'rebuild']
+
+  try {
+    args = [
+      process.execPath,
+      path.join(require.resolve('node-gyp/package.json'), '..', require('node-gyp/package.json').bin['node-gyp']),
+      'rebuild'
+    ]
+  } catch (_) {}
+
+  proc.spawn(args[0], args.slice(1), { stdio: 'inherit' }).on('exit', function (code) {
+    if (code || !process.argv[3]) process.exit(code)
+    exec(process.argv[3]).on('exit', function (code) {
+      process.exit(code)
+    })
+  })
+}
+
+function preinstall () {
+  if (!process.argv[2]) return build()
+  exec(process.argv[2]).on('exit', function (code) {
+    if (code) process.exit(code)
+    build()
+  })
+}
+
+function exec (cmd) {
+  if (process.platform !== 'win32') {
+    var shell = os.platform() === 'android' ? 'sh' : '/bin/sh'
+    return proc.spawn(shell, ['-c', '--', cmd], {
+      stdio: 'inherit'
+    })
+  }
+
+  return proc.spawn(process.env.comspec || 'cmd.exe', ['/s', '/c', '"' + cmd + '"'], {
+    windowsVerbatimArguments: true,
+    stdio: 'inherit'
+  })
+}
+
+function buildFromSource () {
+  return hasFlag('--build-from-source') || process.env.npm_config_build_from_source === 'true'
+}
+
+function verbose () {
+  return hasFlag('--verbose') || process.env.npm_config_loglevel === 'verbose'
+}
+
+// TODO (next major): remove in favor of env.npm_config_* which works since npm
+// 0.1.8 while npm_config_argv will stop working in npm 7. See npm/rfcs#90
+function hasFlag (flag) {
+  if (!process.env.npm_config_argv) return false
+
+  try {
+    return JSON.parse(process.env.npm_config_argv).original.indexOf(flag) !== -1
+  } catch (_) {
+    return false
+  }
+}

--- a/install.js
+++ b/install.js
@@ -1,3 +1,5 @@
+// To compact with `npm install --no-bin-links`. We avoid to use `node-gyp-build` because it will failed caused by child_process.
+
 const tryLoadPreBuilt = require('node-gyp-build');
 const proc = require('child_process')
 const os = require('os')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qjsc",
-  "version": "0.2.9-beta.1",
+  "version": "0.2.9",
   "description": "Node.js addon for the Quickjs compiler",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qjsc",
-  "version": "0.2.8",
+  "version": "0.2.9-beta.1",
   "description": "Node.js addon for the Quickjs compiler",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
如果预构建的产物无法运行，就运行 node-gyp 重新构建。

支付宝小程序的安装依赖 --no-bin-links 参数，无法使用 node-gyp-build 原先的逻辑，因此 fork 一份代码到现在的仓库内。

